### PR TITLE
Add `Transparent_atomic` module

### DIFF
--- a/src/Multicore_magic.ml
+++ b/src/Multicore_magic.ml
@@ -1,4 +1,5 @@
 include Padding
+module Transparent_atomic = Transparent_atomic
 
 let[@inline] fenceless_get (atomic : 'a Atomic.t) = !(Obj.magic atomic : 'a ref)
 

--- a/src/Multicore_magic.ml
+++ b/src/Multicore_magic.ml
@@ -1,7 +1,8 @@
 include Padding
 module Transparent_atomic = Transparent_atomic
 
-let[@inline] fenceless_get (atomic : 'a Atomic.t) = !(Obj.magic atomic : 'a ref)
+let[@inline] fenceless_get (atomic : 'a Atomic.t) =
+  !(Sys.opaque_identity (Obj.magic atomic : 'a ref))
 
 let[@inline] fenceless_set (atomic : 'a Atomic.t) value =
   (Obj.magic atomic : 'a ref) := value

--- a/src/transparent_atomic.ml
+++ b/src/transparent_atomic.ml
@@ -1,0 +1,21 @@
+type 'a t = 'a ref
+
+open struct
+  external as_atomic : 'a t -> 'a Atomic.t = "%identity"
+  external of_atomic : 'a Atomic.t -> 'a t = "%identity"
+end
+
+let[@inline] make x = of_atomic (Atomic.make x)
+
+let[@inline] make_contended x =
+  of_atomic (Padding.copy_as_padded (Atomic.make x))
+
+let[@inline] get x = Atomic.get (Sys.opaque_identity (as_atomic x))
+let[@inline] fenceless_get x = !(Sys.opaque_identity x)
+let[@inline] compare_and_set x b a = Atomic.compare_and_set (as_atomic x) b a
+let[@inline] exchange x v = Atomic.exchange (as_atomic x) v
+let[@inline] set x v = Atomic.set (as_atomic x) v
+let[@inline] fenceless_set x v = x := v
+let[@inline] fetch_and_add x v = Atomic.fetch_and_add (as_atomic x) v
+let[@inline] incr x = Atomic.incr (as_atomic x)
+let[@inline] decr x = Atomic.decr (as_atomic x)

--- a/test/Multicore_magic_test.ml
+++ b/test/Multicore_magic_test.ml
@@ -71,6 +71,17 @@ let fence () =
     Multicore_magic.fence atomic;
     Atomic.get atomic = 76)
 
+let transparent_atomic v0 v1 v2 () =
+  let x = Multicore_magic.Transparent_atomic.make_contended v0 in
+  assert (v0 = Multicore_magic.Transparent_atomic.fenceless_get x);
+  assert (v0 = Multicore_magic.Transparent_atomic.get x);
+  Multicore_magic.Transparent_atomic.set x v1;
+  assert (v1 = Multicore_magic.Transparent_atomic.fenceless_get x);
+  assert (v1 = Multicore_magic.Transparent_atomic.get x);
+  Multicore_magic.Transparent_atomic.fenceless_set x v2;
+  assert (v2 = Multicore_magic.Transparent_atomic.fenceless_get x);
+  assert (v2 = Multicore_magic.Transparent_atomic.get x)
+
 let () =
   Alcotest.run "multicore-magic"
     [
@@ -91,4 +102,8 @@ let () =
       ("fenceless_get", [ Alcotest.test_case "" `Quick fenceless_get ]);
       ("fenceless_set", [ Alcotest.test_case "" `Quick fenceless_set ]);
       ("fence", [ Alcotest.test_case "" `Quick fence ]);
+      ( "transparent_atomic with floats",
+        [ Alcotest.test_case "" `Quick (transparent_atomic 4.2 1.01 7.6) ] );
+      ( "transparent_atomic with ints",
+        [ Alcotest.test_case "" `Quick (transparent_atomic 42 101 76) ] );
     ]


### PR DESCRIPTION
This PR adds the `Transparent_atomic` module and also prevents CSE of `fenceless_get`.

The module is intended as a drop-in replacement for `Stdlib.Atomic`.  It works around the CSE bug in OCaml 5.0.0 and 5.1.0.  It also use a typing hack to avoid the problem in OCaml 5 that prevents the compiler from properly optimizing accesses of arrays of atomics.  This can make a difference in both performance and size of generated code when manipulating arrays of atomics.