### PR TITLE
Add `Atomic_array`

### DIFF
--- a/src/boxed5/dune
+++ b/src/boxed5/dune
@@ -1,0 +1,7 @@
+(library
+ (name multicore_magic_atomic_array_boxed5)
+ (package multicore-magic)
+ (enabled_if
+  (and
+   (<= 5.3.0 %{ocaml_version})))
+ (wrapped false))

--- a/src/boxed5/multicore_magic_atomic_array.ml
+++ b/src/boxed5/multicore_magic_atomic_array.ml
@@ -1,0 +1,17 @@
+type 'a t = 'a Atomic.t array
+
+let[@inline] at (type a) (xs : a t) i : a Atomic.t =
+  (* ['a t] does not contain [float]s. *)
+  Obj.magic (Array.unsafe_get (Obj.magic xs : a ref array) i)
+
+let[@inline] make n v = Array.init n @@ fun _ -> Atomic.make v
+let[@inline] init n fn = Array.init n @@ fun i -> Atomic.make (fn i)
+let[@inline] of_array xs = init (Array.length xs) (Array.unsafe_get xs)
+
+external length : 'a array -> int = "%array_length"
+
+let[@inline] unsafe_fenceless_set xs i v = Obj.magic (at xs i) := v
+let[@inline] unsafe_fenceless_get xs i = !(Obj.magic (at xs i))
+
+let[@inline] unsafe_compare_and_set xs i b a =
+  Atomic.compare_and_set (at xs i) b a

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,13 @@
 (library
  (name Multicore_magic)
- (public_name multicore-magic))
+ (public_name multicore-magic)
+ (libraries
+  (select
+   multicore_magic.ml
+   from
+   (multicore_magic_atomic_array_unboxed5 -> multicore_magic.common.ml)
+   (multicore_magic_atomic_array_boxed5 -> multicore_magic.common.ml)
+   (multicore_magic_atomic_array_ocaml4 -> multicore_magic.common.ml))))
 
 ;;
 

--- a/src/multicore_magic.common.ml
+++ b/src/multicore_magic.common.ml
@@ -9,3 +9,5 @@ let[@inline] fenceless_set (atomic : 'a Atomic.t) value =
   (Obj.magic atomic : 'a ref) := value
 
 let[@inline] fence atomic = Atomic.fetch_and_add atomic 0 |> ignore
+
+module Atomic_array = Multicore_magic_atomic_array

--- a/src/ocaml4/dune
+++ b/src/ocaml4/dune
@@ -1,0 +1,6 @@
+(library
+ (name multicore_magic_atomic_array_ocaml4)
+ (package multicore-magic)
+ (enabled_if
+  (< %{ocaml_version} 5.0.0))
+ (wrapped false))

--- a/src/ocaml4/multicore_magic_atomic_array.ml
+++ b/src/ocaml4/multicore_magic_atomic_array.ml
@@ -1,0 +1,48 @@
+type !'a t = 'a array
+
+let[@inline] unsafe_fenceless_set xs i x =
+  (* We never create [float array]s. *)
+  Array.unsafe_set (Obj.magic xs : string array) i (Obj.magic x)
+
+let[@inline never] make n x =
+  (* We never create [float array]s. *)
+  if Obj.tag (Obj.repr x) != Obj.double_tag then Array.make n x
+  else
+    let xs = Array.make n (Obj.magic ()) in
+    for i = 0 to n - 1 do
+      unsafe_fenceless_set xs i x
+    done;
+    xs
+
+let[@inline never] init n fn =
+  (* We never create [float array]s. *)
+  let ys = Array.make n (Obj.magic ()) in
+  for i = 0 to n - 1 do
+    unsafe_fenceless_set ys i (fn i)
+  done;
+  ys
+
+let[@inline never] of_array xs =
+  if Obj.tag (Obj.repr xs) != Obj.double_array_tag then Array.copy xs
+  else init (Array.length xs) (fun i -> Array.unsafe_get xs i)
+
+external length : 'a array -> int = "%array_length"
+
+let[@inline] unsafe_fenceless_get xs i =
+  (* We never create [float array]s. *)
+  Obj.magic
+    (Sys.opaque_identity (Array.unsafe_get (Obj.magic xs : string array) i))
+
+let[@poll error] [@inline never] unsafe_compare_and_set (xs : string array) i b
+    a =
+  let before = Array.unsafe_get xs i in
+  before == b
+  && begin
+       Array.unsafe_set xs i a;
+       true
+     end
+
+let[@inline] unsafe_compare_and_set (type a) (xs : a array) i (b : a) (a : a) =
+  unsafe_compare_and_set
+    (Obj.magic xs : string array)
+    i (Obj.magic b) (Obj.magic a)

--- a/src/unboxed5/dune
+++ b/src/unboxed5/dune
@@ -1,0 +1,11 @@
+(library
+ (name multicore_magic_atomic_array_unboxed5)
+ (package multicore-magic)
+ (enabled_if
+  (and
+   (<= 5.0.0 %{ocaml_version})
+   (< %{ocaml_version} 5.3.0)))
+ (foreign_stubs
+  (language c)
+  (names multicore_magic_atomic_array))
+ (wrapped false))

--- a/src/unboxed5/multicore_magic_atomic_array.c
+++ b/src/unboxed5/multicore_magic_atomic_array.c
@@ -1,0 +1,9 @@
+#include "caml/mlvalues.h"
+#include "caml/memory.h"
+#include "caml/alloc.h"
+
+CAMLprim value caml_multicore_magic_atomic_array_cas(
+  value obj, intnat field, value oldval, value newval)
+{
+  return Val_int(caml_atomic_cas_field(obj, Int_val(field), oldval, newval));
+}

--- a/src/unboxed5/multicore_magic_atomic_array.ml
+++ b/src/unboxed5/multicore_magic_atomic_array.ml
@@ -1,0 +1,43 @@
+type !'a t = 'a array
+
+let[@inline] unsafe_fenceless_set xs i x =
+  (* We never create [float array]s. *)
+  Array.unsafe_set (Obj.magic xs : string array) i (Obj.magic x)
+
+let[@inline never] make n x =
+  (* We never create [float array]s. *)
+  if Obj.tag (Obj.repr x) != Obj.double_tag then Array.make n x
+  else
+    let xs = Array.make n (Obj.magic ()) in
+    for i = 0 to n - 1 do
+      unsafe_fenceless_set xs i x
+    done;
+    xs
+
+let[@inline never] init n fn =
+  (* We never create [float array]s. *)
+  let ys = Array.make n (Obj.magic ()) in
+  for i = 0 to n - 1 do
+    unsafe_fenceless_set ys i (fn i)
+  done;
+  ys
+
+let[@inline never] of_array xs =
+  if Obj.tag (Obj.repr xs) != Obj.double_array_tag then Array.copy xs
+  else init (Array.length xs) (fun i -> Array.unsafe_get xs i)
+
+external length : 'a array -> int = "%array_length"
+
+let[@inline] unsafe_fenceless_get xs i =
+  (* We never create [float array]s. *)
+  Obj.magic
+    (Sys.opaque_identity (Array.unsafe_get (Obj.magic xs : string array) i))
+
+let[@inline] unsafe_compare_and_set xs i b a : bool =
+  let open struct
+    external unsafe_compare_and_set_as_int :
+      'a array -> (int[@untagged]) -> 'a -> 'a -> (int[@untagged])
+      = "caml_multicore_magic_atomic_array_cas" "caml_atomic_cas_field"
+    [@@noalloc]
+  end in
+  Obj.magic (unsafe_compare_and_set_as_int xs i b a)

--- a/test/Multicore_magic_test.ml
+++ b/test/Multicore_magic_test.ml
@@ -157,6 +157,21 @@ let test_instantaneous_domain_index () =
     stress ()
   end
 
+let atomic_array () =
+  let module Atomic_array = Multicore_magic.Atomic_array in
+  let floats = Atomic_array.of_array [| 1.01; 4.2 |] in
+  assert (Obj.tag (Obj.repr floats) != Obj.double_array_tag);
+  assert (Atomic_array.length floats = 2);
+  assert (Atomic_array.unsafe_fenceless_get floats 0 = 1.01);
+  assert (Atomic_array.unsafe_fenceless_get floats 1 = 4.2);
+  assert (
+    Atomic_array.unsafe_compare_and_set floats 1
+      (Atomic_array.unsafe_fenceless_get floats 1)
+      7.6);
+  assert (Atomic_array.unsafe_fenceless_get floats 1 = 7.6);
+  Atomic_array.unsafe_fenceless_set floats 0 9.6;
+  assert (Atomic_array.unsafe_fenceless_get floats 0 = 9.6)
+
 let () =
   Alcotest.run "multicore-magic"
     [
@@ -183,4 +198,5 @@ let () =
         [ Alcotest.test_case "" `Quick (transparent_atomic 42 101 76) ] );
       ( "instantaneous_domain_index",
         [ Alcotest.test_case "" `Quick test_instantaneous_domain_index ] );
+      ("Atomic_array", [ Alcotest.test_case "" `Quick atomic_array ]);
     ]


### PR DESCRIPTION
This PR adds an `Atomic_array` module that gives a limited functionality equivalent of `'a Atomic.t array` using internally only an `'a array` based on the [`caml_atomic_cas_field`](https://github.com/ocaml/ocaml/blob/7a5d882d22cdd32b6319e9be680bd1a3d67377a9/runtime/memory.c#L313-L338) function that already exists in the OCaml 5.0.0 - 5.2.0 runtime.

The benefit of this is that only 1 word, instead of 3 words, is used per array element (i.e. a significant drop in memory use and allocations) and an indirection is avoided (i.e. less pointer chasing).  This translates to, depending on the case, to significant performance improvements in the implementation of array based lock-free data structures (up to 40% improvement has been seen in some cases).