### PR TITLE
Require `dune` 3.14, `odoc` 2.4.1, and `sherlodoc` 0.2

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.3)
+(lang dune 3.14)
 
 (name multicore-magic)
 
@@ -23,6 +23,7 @@
  (depends
   (ocaml
    (>= 4.12.0))
+  ;; Test dependencies
   (domain_shims
    (and
     (>= 0.1.0)
@@ -31,7 +32,12 @@
    (and
     (>= 1.7.0)
     :with-test))
+  ;; Documentation dependencies
+  (sherlodoc
+   (and
+    (>= 0.2)
+    :with-doc))
   (odoc
    (and
-    (>= 2.2.0)
+    (>= 2.4.1)
     :with-doc))))

--- a/multicore-magic.opam
+++ b/multicore-magic.opam
@@ -7,11 +7,12 @@ license: "ISC"
 homepage: "https://github.com/ocaml-multicore/multicore-magic"
 bug-reports: "https://github.com/ocaml-multicore/multicore-magic/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.14"}
   "ocaml" {>= "4.12.0"}
   "domain_shims" {>= "0.1.0" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
-  "odoc" {>= "2.2.0" & with-doc}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This should ensure you get the search bar in the generated docs.

This also hopefully avoids the [`dune` bug with `select from`](https://github.com/ocaml/opam-repository/pull/25947).