### PR TITLE
Add `copy_as ~padded`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Next version
+
+- Add `copy_as ~padded` for convenient optional padding (@polytypic)
+
 ## 2.2.0
 
 - Add (unboxed) `Atomic_array` (@polytypic)

--- a/src/Multicore_magic.mli
+++ b/src/Multicore_magic.mli
@@ -38,6 +38,10 @@ val copy_as_padded : 'a -> 'a
     Padding changes the length of an array.  If you need to pad an array, use
     {!make_padded_array}. *)
 
+val copy_as : ?padded:bool -> 'a -> 'a
+(** [copy_as x] by default simply returns [x].  When [~padded:true] is
+    explicitly specified, returns {{!copy_as_padded} [copy_as_padded x]}. *)
+
 val make_padded_array : int -> 'a -> 'a array
 (** Creates a padded array.  The length of the returned array includes padding.
     Use {!length_of_padded_array} to get the unpadded length. *)

--- a/src/padding.ml
+++ b/src/padding.ml
@@ -21,6 +21,9 @@ let copy_as_padded (o : 'a) : 'a =
   end
   else Obj.obj o
 
+let copy_as ?padded x =
+  match padded with None | Some false -> x | Some true -> copy_as_padded x
+
 let make_padded_array n x =
   let a = Array.make (n + num_padding_words) x in
   if Obj.is_block (Obj.repr x) then


### PR DESCRIPTION
This is convenient for making padding optional and has use cases in many other libraries.