### PR TITLE
Do not test with `conf-npm` on `x86_32`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,6 +38,7 @@
     :with-test))
   (conf-npm
    (and
+    (<> :arch "x86_32")
     (<> :os "win32")
     :with-test))
   ;; Documentation dependencies

--- a/multicore-magic.opam
+++ b/multicore-magic.opam
@@ -12,7 +12,7 @@ depends: [
   "domain_shims" {>= "0.1.0" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "js_of_ocaml" {>= "5.4.0" & with-test}
-  "conf-npm" {os != "win32" & with-test}
+  "conf-npm" {arch != "x86_32" & os != "win32" & with-test}
   "sherlodoc" {>= "0.2" & with-doc}
   "odoc" {>= "2.4.1" & with-doc}
 ]

--- a/test/dune
+++ b/test/dune
@@ -16,6 +16,7 @@
  (modes js)
  (build_if
   (and
+   (<> %{architecture} i386)
    (<> %{os_type} Win32)))
  (action
   ;; It is fine if 'node:fs' cannot be found.  js_of_ocaml>=5.9 does not like


### PR DESCRIPTION
The installation of `conf-npm` tends to fail on CI on `x86_32` and, indeed, it just failed on `opam-ci`.  As we test on various other architectures, it is probably best to just skip testing on the legacy `x86_32`.